### PR TITLE
Remove fetchWithLinks and parser dependency

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,4 @@
 export { ajaxCall, ajaxJsonCall, ajaxFormCall, ajaxFormFileUpload, ajaxFileDownload, sendBeacon, checkUrlExistence, appendParamToRemedyCorsBug } from './ajax';
 export type { AjaxJsonCallOptionsT, AjaxFileDownloadOptionsT } from './ajax';
-export { fromString, toString, parseLinkHeader, fetchWithLinks } from './link-header';
+export { fromString, toString, parseLinkHeader } from './link-header';
 export type { LinkName, LinkPathT, LinksT } from './link-header';

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.fetchWithLinks = exports.parseLinkHeader = exports.toString = exports.fromString = exports.appendParamToRemedyCorsBug = exports.checkUrlExistence = exports.sendBeacon = exports.ajaxFileDownload = exports.ajaxFormFileUpload = exports.ajaxFormCall = exports.ajaxJsonCall = exports.ajaxCall = void 0;
+exports.parseLinkHeader = exports.toString = exports.fromString = exports.appendParamToRemedyCorsBug = exports.checkUrlExistence = exports.sendBeacon = exports.ajaxFileDownload = exports.ajaxFormFileUpload = exports.ajaxFormCall = exports.ajaxJsonCall = exports.ajaxCall = void 0;
 var ajax_1 = require("./ajax");
 Object.defineProperty(exports, "ajaxCall", { enumerable: true, get: function () { return ajax_1.ajaxCall; } });
 Object.defineProperty(exports, "ajaxJsonCall", { enumerable: true, get: function () { return ajax_1.ajaxJsonCall; } });
@@ -14,4 +14,3 @@ var link_header_1 = require("./link-header");
 Object.defineProperty(exports, "fromString", { enumerable: true, get: function () { return link_header_1.fromString; } });
 Object.defineProperty(exports, "toString", { enumerable: true, get: function () { return link_header_1.toString; } });
 Object.defineProperty(exports, "parseLinkHeader", { enumerable: true, get: function () { return link_header_1.parseLinkHeader; } });
-Object.defineProperty(exports, "fetchWithLinks", { enumerable: true, get: function () { return link_header_1.fetchWithLinks; } });

--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -10,10 +10,5 @@ declare export {
   appendParamToRemedyCorsBug,
 } from "./ajax";
 export type { AjaxJsonCallOptionsT, AjaxFileDownloadOptionsT } from "./ajax";
-declare export {
-  fromString,
-  toString,
-  parseLinkHeader,
-  fetchWithLinks,
-} from "./link-header";
+declare export { fromString, toString, parseLinkHeader } from "./link-header";
 export type { LinkName, LinkPathT, LinksT } from "./link-header";

--- a/dist/link-header.d.ts
+++ b/dist/link-header.d.ts
@@ -1,4 +1,3 @@
-import type { ParserT } from '@freckle/parser';
 export type LinkName = 'first' | 'previous' | 'next' | 'last';
 export type LinkPathT = string;
 export declare function fromString(linkUrl: string): LinkPathT;
@@ -7,9 +6,3 @@ export type LinksT = {
     [name in LinkName]: LinkPathT;
 };
 export declare function parseLinkHeader(linkHeader: string | null): LinksT;
-type ResponseT<T> = {
-    response: T;
-    links: LinksT;
-};
-export declare function fetchWithLinks<T>(url: string, parseAttrs: ParserT<T>): Promise<ResponseT<T>>;
-export {};

--- a/dist/link-header.js
+++ b/dist/link-header.js
@@ -3,9 +3,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.fetchWithLinks = exports.parseLinkHeader = exports.toString = exports.fromString = void 0;
+exports.parseLinkHeader = exports.toString = exports.fromString = void 0;
 const isNil_1 = __importDefault(require("lodash/isNil"));
-const parser_1 = require("@freckle/parser");
 function fromString(linkUrl) {
     return linkUrl;
 }
@@ -49,26 +48,3 @@ const toLinkName = (rawName) => {
             throw new Error(`Could not parse ${rawName}`);
     }
 };
-function fetchWithLinks(url, parseAttrs) {
-    return new Promise((resolve, reject) => {
-        $.ajax({
-            url,
-            type: 'GET'
-        })
-            .then((response, _textStatus, jqXHR) => {
-            try {
-                const linkHeader = jqXHR.getResponseHeader('Link');
-                const links = parseLinkHeader(linkHeader);
-                const parsedResponse = parser_1.Parser.run(response, parseAttrs);
-                resolve({ response: parsedResponse, links });
-            }
-            catch (error) {
-                reject(error);
-            }
-        })
-            .fail((_jqXHR, _textStatus, errorThrown) => {
-            reject(new Error(errorThrown));
-        });
-    });
-}
-exports.fetchWithLinks = fetchWithLinks;

--- a/dist/link-header.js.flow
+++ b/dist/link-header.js.flow
@@ -1,5 +1,4 @@
 // @flow
-import type { ParserT } from "@freckle/parser";
 export type LinkName = "first" | "previous" | "next" | "last";
 export type LinkPathT = string;
 declare export function fromString(linkUrl: string): LinkPathT;
@@ -9,11 +8,3 @@ export type LinksT = $ObjMapi<
   <name>(name) => LinkPathT
 >;
 declare export function parseLinkHeader(linkHeader: string | null): LinksT;
-declare type ResponseT<T> = {|
-  response: T,
-  links: LinksT,
-|};
-declare export function fetchWithLinks<T>(
-  url: string,
-  parseAttrs: ParserT<T>
-): Promise<ResponseT<T>>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freckle/ajax",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Freckle ajax helpers",
   "author": "Freckle",
   "license": "MIT",
@@ -16,7 +16,6 @@
   },
   "dependencies": {
     "@freckle/maybe": "^2.1.0",
-    "@freckle/parser": "^1.3.3",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,5 @@ export {
 } from './ajax'
 export type {AjaxJsonCallOptionsT, AjaxFileDownloadOptionsT} from './ajax'
 
-export {fromString, toString, parseLinkHeader, fetchWithLinks} from './link-header'
+export {fromString, toString, parseLinkHeader} from './link-header'
 export type {LinkName, LinkPathT, LinksT} from './link-header'

--- a/src/link-header.ts
+++ b/src/link-header.ts
@@ -1,6 +1,4 @@
 import isNil from 'lodash/isNil'
-import {Parser} from '@freckle/parser'
-import type {ParserT} from '@freckle/parser'
 
 export type LinkName = 'first' | 'previous' | 'next' | 'last'
 export type LinkPathT = string
@@ -55,31 +53,4 @@ const toLinkName = (rawName: string): LinkName => {
     default:
       throw new Error(`Could not parse ${rawName}`)
   }
-}
-
-type ResponseT<T> = {
-  response: T
-  links: LinksT
-}
-
-export function fetchWithLinks<T>(url: string, parseAttrs: ParserT<T>): Promise<ResponseT<T>> {
-  return new Promise((resolve, reject) => {
-    $.ajax({
-      url,
-      type: 'GET'
-    })
-      .then((response, _textStatus, jqXHR) => {
-        try {
-          const linkHeader = jqXHR.getResponseHeader('Link')
-          const links = parseLinkHeader(linkHeader)
-          const parsedResponse = Parser.run(response, parseAttrs)
-          resolve({response: parsedResponse, links})
-        } catch (error) {
-          reject(error)
-        }
-      })
-      .fail((_jqXHR, _textStatus, errorThrown) => {
-        reject(new Error(errorThrown))
-      })
-  })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,7 +404,6 @@ __metadata:
   resolution: "@freckle/ajax@workspace:."
   dependencies:
     "@freckle/maybe": ^2.1.0
-    "@freckle/parser": ^1.3.3
     "@types/jest": ^28.1.1
     "@types/jquery": ^3.5.16
     "@types/lodash": ^4.14.191
@@ -420,41 +419,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@freckle/exhaustive@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "@freckle/exhaustive@npm:1.0.1"
-  checksum: 6c4815501099ca753916b40751ec9f9450931615e20e0f37866eca8da4230c02d9f3145c45432572205e53e2c041fa659617446173a67932daa4e7216ef62611
-  languageName: node
-  linkType: hard
-
 "@freckle/maybe@npm:^2.1.0":
   version: 2.1.0
   resolution: "@freckle/maybe@npm:2.1.0"
   dependencies:
     lodash: ^4.17.21
   checksum: 2c3753d6d448725d25163261512b5f6598ecea8d68c4955d44fbda2a6f257a7a4f6a4b6ce52c4ba334302a7376064ee04fc2b814d954060a1d60379d5d5531a1
-  languageName: node
-  linkType: hard
-
-"@freckle/non-empty@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@freckle/non-empty@npm:2.1.2"
-  dependencies:
-    "@freckle/maybe": ^2.1.0
-    lodash: 4.17.21
-  checksum: 578196be495dfb2838cabbed6e3d9d0de67b6e537fdd56ed2aa677c7f8b6472927b3ed2f0b5a7c0b8ea0feda514549e6501af7475ad2f6e27315423cd5f9edc7
-  languageName: node
-  linkType: hard
-
-"@freckle/parser@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "@freckle/parser@npm:1.3.3"
-  dependencies:
-    "@freckle/exhaustive": ^1.0.1
-    "@freckle/non-empty": ^2.1.2
-    lodash: 4.17.21
-    moment-timezone: 0.5.35
-  checksum: 0c99420409fba89b05101935f27d493356af0cee3a0793d020ba33acbbd6011585fea15f20ab2d4fc2dda67f7253f781ab2867c17c87dcbe9bd28cfad33d74ed
   languageName: node
   linkType: hard
 
@@ -3721,7 +3691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.20, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
@@ -4048,22 +4018,6 @@ __metadata:
   bin:
     mkdirp: bin/cmd.js
   checksum: a96865108c6c3b1b8e1d5e9f11843de1e077e57737602de1b82030815f311be11f96f09cce59bd5b903d0b29834733e5313f9301e3ed6d6f6fba2eae0df4298f
-  languageName: node
-  linkType: hard
-
-"moment-timezone@npm:0.5.35":
-  version: 0.5.35
-  resolution: "moment-timezone@npm:0.5.35"
-  dependencies:
-    moment: ">= 2.9.0"
-  checksum: 0f3907282dc9ae3d405fefaccf486dc4222945ff479127fd269e6c4ddc25e526e7ca9e849d6bf941c871bd17e875b256bdb276137a55db9fce4177c792a003df
-  languageName: node
-  linkType: hard
-
-"moment@npm:>= 2.9.0":
-  version: 2.29.4
-  resolution: "moment@npm:2.29.4"
-  checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`fetchWithLinks` is used by only a single Freckle application and depends on `@freckle/parser`. This domain-specific function should be moved into the application requiring it.