### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/add-asana-comment.yml
+++ b/.github/workflows/add-asana-comment.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   link-asana-task:
     if: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   checklist:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: freckle/commenter-action@main

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -3,11 +3,12 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   checklist:
-    permissions:
-      contents: read
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: freckle/commenter-action@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/freckle/ajax-js/security/code-scanning/5](https://github.com/freckle/ajax-js/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is sufficient for the current workflow's operations (e.g., checking out the repository and running tests). This change ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
